### PR TITLE
Cite IPScan6 and change links for protein families game

### DIFF
--- a/docs/citing.rst
+++ b/docs/citing.rst
@@ -18,9 +18,14 @@ Llinares-López, Aron Marchler-Bauer, Laetitia Meng-Papaxanthos, Huaiyu Mi, Darr
 Orengo, Arun P Pandurangan, Damiano Piovesan, Catherine Rivoire, Christian J A Sigrist, Narmada Thanki, 
 Françoise Thibaud-Nissen, Paul D Thomas, Silvio C E Tosatto, Cathy H Wu, Alex Bateman, Nucleic Acids Research (2024), gkae1082, PMID: `39565202 <https://europepmc.org/article/MED/39565202>`_ 
 
+InterProScan 6
+===============
+`InterProScan 6: a modern large-scale protein function annotation pipeline <https://doi.org/10.1093/bioadv/vbag141>`_
+Matthias Blum, Emma Hobbs, Laise Florentino, Alex Bateman. Bioinformatics Advances (2026), PMID: `42222668 <https://europepmc.org/article/MED/42222668>`_
 
-InterProScan
-============
+
+InterProScan 5
+===============
 `InterProScan 5: genome-scale protein function classification <https://doi.org/10.1093/bioinformatics/btu031>`_
 Philip Jones, David Binns, Hsin-Yu Chang, Matthew Fraser, Weizhong Li, Craig McAnulla, Hamish McWilliam, John Maslen, Alex Mitchell, Gift Nuka, Sebastien Pesseat, Antony F. Quinn, Amaia Sangrador-Vegas, Maxim Scheremetjew, Siew-Yit Yong, Rodrigo Lopez, Sarah Hunter,
 Bioinformatics (2014), PMID: `24451626 <https://europepmc.org/article/MED/24451626>`_

--- a/docs/protein_families_game.rst
+++ b/docs/protein_families_game.rst
@@ -11,7 +11,7 @@ The Protein families game contains 42 cards divided in 7 families (6 protein car
 of families by asking the other players for the protein cards you are missing in your hand to complete your families. The game logic 
 is similar to the Happy families and Go Fish games.
 
-You can download a printable version of the game (PDF) from this `link <https://drive.google.com/drive/folders/1aq2YytFCfP6k_mvHLhvuH-Kk7VKS5Opl>`_, or you can put in a `request to organise the Protein families game activity in person <https://www.ebi.ac.uk/about/contact/support/interpro>`_.
+You can download a printable version of the game (PDF) from this `link <https://drive.google.com/drive/folders/1aq2YytFCfP6k_mvHLhvuH-Kk7VKS5Opl>`_.
 
 Translation
 ===========

--- a/docs/protein_families_game.rst
+++ b/docs/protein_families_game.rst
@@ -11,31 +11,7 @@ The Protein families game contains 42 cards divided in 7 families (6 protein car
 of families by asking the other players for the protein cards you are missing in your hand to complete your families. The game logic 
 is similar to the Happy families and Go Fish games.
 
-The game is available to play online by clicking on the image below, or you can put a `request to organise the Protein families game activity in person <https://www.ebi.ac.uk/about/contact/support/interpro>`_.
-
-.. raw:: html
-
-  <div style="position: center; height: 0; overflow: hidden; max-width: 100%; height: auto;">
-  <iframe src="https://tabletopia.com/games/protein-families/680x340" width="680" height="340" frameborder="0" allowtransparency="true" scrolling="no"></iframe>
-  </div>
-
-|
-
-Game rules
-==========
-
-The game rules in English can be `downloaded <https://c.tabletopia.com/games/protein-families/rules/protein-families-game-rules-online/en>`_.
-
-The video below explains how to interact with the different objects in the online platform. 
-
-.. raw:: html
-
-
-  <div style="position: center; height: 0; overflow: hidden; max-width: 100%; height: auto;">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/EjrKx9hLYR8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-  </div>
-
-|
+You can download a printable version of the game (PDF) from this `link <https://drive.google.com/drive/folders/1aq2YytFCfP6k_mvHLhvuH-Kk7VKS5Opl>`_, or you can put in a `request to organise the Protein families game activity in person <https://www.ebi.ac.uk/about/contact/support/interpro>`_.
 
 Translation
 ===========


### PR DESCRIPTION
As requested in [IBU-12494](https://embl.atlassian.net/browse/IBU-12494) and [IBU-12470](https://embl.atlassian.net/browse/IBU-12470):

- IPScan 6 paper is now added to the citation list. Links were checked;
- Protein family game links, iframe and youtube video associated with Tabletopia have been removed (EBI blocks the page as per policy). A GDrive link to download the printable .pdf version of the game has been added. This change will automatically be pulled by the InterPro website.

Let me know if you spot anything weird. Otherwise I'll build again ASAP.